### PR TITLE
Windows: Fix OpenMP Linkage

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,7 @@ if errorlevel 1 exit 1
 
 :: OpenMP flags
 set "CXXFLAGS=%CXXFLAGS% -openmp"
-set "LDFLAGS=%LDFLAGS% -openmp"
+:: set "LDFLAGS=%LDFLAGS% -openmp"
 
 :: configure
 cmake ^
@@ -17,6 +17,7 @@ cmake ^
     -DCMAKE_BUILD_TYPE=Release            ^
     -DCMAKE_C_COMPILER=clang-cl           ^
     -DCMAKE_CXX_COMPILER=clang-cl         ^
+    -DCMAKE_EXE_LINKER_FLAGS="-fopenmp"   ^
     -DCMAKE_INSTALL_LIBDIR=lib            ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_INSTALL_PYTHONDIR=%SP_DIR%    ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,10 @@
 if not exist %LIBRARY_PREFIX%\bin md %LIBRARY_PREFIX%\bin
 if errorlevel 1 exit 1
 
+:: OpenMP flags
+set "CXXFLAGS=%CXXFLAGS% -openmp"
+set "LDFLAGS=%LDFLAGS% -openmp"
+
 :: configure
 cmake ^
     -S %SRC_DIR% -B build                 ^


### PR DESCRIPTION
Windows shows unknown OpenMP types at link type if used in public symbols.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
